### PR TITLE
⚡️ perf: /post 페이지 초기 로드 시 에디터 번들 지연 로드

### DIFF
--- a/components/editor/Base.tsx
+++ b/components/editor/Base.tsx
@@ -1,29 +1,18 @@
 'use client';
 
 import EditorPlaceholder from '@/components/editor/EditorPlaceholder';
-import MarkdownEditor from '@/components/editor/MarkdownEditor';
-import UtilButtonList from '@/components/editor/UtilButtonList';
-import { EditorProvider } from '@/contexts/EditorContext';
 import dynamic from 'next/dynamic';
 
-const Loading = dynamic(() => import('@/components/common/Loading'), { ssr: false });
+const EditorWorkspace = dynamic(() => import('@/components/editor/EditorWorkspace'), {
+  ssr: false,
+  loading: () => <div className="flex flex-1 items-center justify-center">불러오는 중...</div>,
+});
 
 export default function Base({ initialTopic, result, loading = false, defaultPreview = false }: { initialTopic: string; result: string; loading?: boolean; defaultPreview?: boolean }) {
   return (
     <>
-      {/* 글 생성되기 전 상태 */}
       {!result && !loading && <EditorPlaceholder />}
-      {/* 글 생성 후 상태 */}
-      {(result || loading) && (
-        <EditorProvider streamedMarkdown={result} initialTopic={initialTopic} initialContent={result} initialMarkdownMode={!defaultPreview}>
-          <div className="relative flex min-h-0 flex-1 flex-col">
-            {loading && <Loading />}
-
-            <MarkdownEditor />
-            <UtilButtonList />
-          </div>
-        </EditorProvider>
-      )}
+      {(result || loading) && <EditorWorkspace initialTopic={initialTopic} result={result} loading={loading} defaultPreview={defaultPreview} />}
     </>
   );
 }

--- a/components/editor/EditorWorkspace.tsx
+++ b/components/editor/EditorWorkspace.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { EditorProvider } from '@/contexts/EditorContext';
+import Loading from '@/components/common/Loading';
+import MarkdownEditor from '@/components/editor/MarkdownEditor';
+import UtilButtonList from '@/components/editor/UtilButtonList';
+
+export default function EditorWorkspace({ initialTopic, result, loading, defaultPreview }: { initialTopic: string; result: string; loading: boolean; defaultPreview: boolean }) {
+  return (
+    <EditorProvider streamedMarkdown={result} initialTopic={initialTopic} initialContent={result} initialMarkdownMode={!defaultPreview}>
+      <div className="relative flex min-h-0 flex-1 flex-col">
+        {loading && <Loading />}
+        <MarkdownEditor />
+        <UtilButtonList />
+      </div>
+    </EditorProvider>
+  );
+}


### PR DESCRIPTION
- MarkdownEditor, EditorProvider를 감싸는 EditorWorkspace 컴포넌트 생성
- 글 생성 요청 또는 기존 글 조회 등 실제로 필요한 시점에만 tiptap/prosemirror/highlight.js 청크가 로드되도록 변경
- /post 최초 진입 시 불필요하게 로드되던 리치 에디터 스택을 분리하여 Speed Index 1.9s → 0.6s로 개선

## PR 유형

- [] 새로운 기능 추가
- [] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

/post 페이지 초기 로드 시 에디터 번들 지연 로드

- MarkdownEditor, EditorProvider를 감싸는 EditorWorkspace 컴포넌트 생성

- 글 생성 요청 또는 기존 글 조회 등 실제로 필요한 시점에만 tiptap/prosemirror/highlight.js 청크가 로드되도록 변경

- /post 최초 진입 시 불필요하게 로드되던 리치 에디터 스택을 분리하여 Speed Index 1.9s → 0.6s로 개선

## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves <#1467694926484472124>
