### PR TITLE
♻️ refactor: 사이드바 초기 렌더링 시 발생하는 CLS(레이아웃 변경) 제거

### DIFF
--- a/app/post/layout.tsx
+++ b/app/post/layout.tsx
@@ -3,6 +3,7 @@ import Sidebar from '@/components/layout/Sidebar';
 import { getMyPosts } from '@/data/functions/post';
 import { createClient } from '@/lib/supabaseServer';
 import type { Metadata } from 'next';
+import { Suspense } from 'react';
 
 const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL ?? 'https://aiscream.vercel.app').replace(/\/$/, '');
 
@@ -26,21 +27,34 @@ export const metadata: Metadata = {
   },
 };
 
-export default async function PostLayout({ children }: { children: React.ReactNode }) {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  const posts = await getMyPosts().catch(() => []);
-
+export default function PostLayout({ children }: { children: React.ReactNode }) {
   return (
     <>
       <Header />
       <div className="relative flex flex-1 overflow-hidden">
-        <Sidebar initialPosts={posts} userEmail={user?.email ?? ''} />
+        <Suspense fallback={<SidebarSkeleton />}>
+          <SidebarWithData />
+        </Suspense>
         <main className="flex-1 overflow-y-auto">{children}</main>
       </div>
     </>
   );
+}
+
+async function SidebarWithData() {
+  const supabase = await createClient();
+
+  // 인증 체크와 글 목록 조회를 병렬로
+  const [
+    {
+      data: { user },
+    },
+    posts,
+  ] = await Promise.all([supabase.auth.getUser(), getMyPosts().catch(() => [])]);
+
+  return <Sidebar initialPosts={posts} userEmail={user?.email ?? ''} />;
+}
+
+function SidebarSkeleton() {
+  return <aside className="z-10 flex w-70 shrink-0 flex-col self-stretch border-r border-base-stroke bg-muted max-pc:absolute max-pc:inset-0 max-pc:w-0 pc:h-dvh pc:w-75" />;
 }

--- a/components/layout/Sidebar.tsx
+++ b/components/layout/Sidebar.tsx
@@ -9,51 +9,44 @@ import { usePostStore } from '@/stores/post-store';
 import PlusIcon from '../common/PlusIcon';
 import ThemeModeToggle from '../common/Toggle';
 import { useModalStore } from '@/stores/modal-store';
-import { useEffect } from 'react';
 
 export default function Sidebar({ initialPosts, userEmail }: { initialPosts: Post[]; userEmail: string }) {
   const { logout } = useAuth();
-  const { toggleSidebar, isSidebarOpen, setSidebarOpen } = useUIStore();
+  const { isSidebarOpen, isCollapsed, toggleCollapsed } = useUIStore();
   const { selectPostId, isChanged } = usePostStore();
   const pathname = usePathname();
 
   const openModal = useModalStore(state => state.openModal);
 
-  useEffect(() => {
-    if (window.innerWidth >= 768) {
-      setSidebarOpen(true);
-    }
-  }, []);
-
   return (
-    <aside id="sidebar" className={`z-10 flex w-70 flex-col self-stretch border-r border-base-stroke bg-muted text-xs transition-all duration-200 max-pc:absolute max-pc:inset-0 pc:h-dvh pc:text-sm ${isSidebarOpen ? 'pc:w-75' : 'max-pc:w-0 pc:w-15.5'}`}>
+    <aside id="sidebar" className={`z-10 flex w-70 flex-col self-stretch border-r border-base-stroke bg-muted text-xs transition-all duration-200 max-pc:absolute max-pc:inset-0 pc:h-dvh pc:text-sm ${isCollapsed ? 'pc:w-15.5' : 'pc:w-75'} ${isSidebarOpen ? '' : 'max-pc:w-0'}`}>
       {/* (only-PC) 사이드바 헤더 */}
-      <header className={`hidden h-15.5 border-b border-base-stroke px-4 py-4.5 pc:flex ${isSidebarOpen ? 'justify-between' : 'justify-center'}`}>
+      <header className={`hidden h-15.5 border-b border-base-stroke px-4 py-4.5 pc:flex ${isCollapsed ? 'justify-center' : 'justify-between'}`}>
         {/* (only-PC) 로고 */}
-        <Link href="/post" aria-label="AiScReam 홈으로 이동" className={`${isSidebarOpen ? 'flex' : 'hidden'} flex items-center gap-1.5 text-lg`}>
+        <Link href="/post" aria-label="AiScReam 홈으로 이동" className={`${isCollapsed ? 'hidden' : 'flex'} items-center gap-1.5 text-lg`}>
           <Image src="/assets/images/logo.png" width={26} height={26} alt="" aria-hidden />
           <span className="itim">AiScReam</span>
         </Link>
 
         {/* (only-PC) 토글 */}
-        <button type="button" aria-expanded={isSidebarOpen} aria-controls="sidebar" aria-label="사이드바 토글" onClick={toggleSidebar} className="cursor-pointer p-2">
-          <Image src={isSidebarOpen ? '/assets/images/ico-chevron-left.svg' : '/assets/images/ico-chevron-right.svg'} width={6} height={12} alt="" className="dark:invert" />
+        <button type="button" aria-expanded={!isCollapsed} aria-controls="sidebar" aria-label="사이드바 토글" onClick={toggleCollapsed} className="cursor-pointer p-2">
+          <Image src={!isCollapsed ? '/assets/images/ico-chevron-left.svg' : '/assets/images/ico-chevron-right.svg'} width={6} height={12} alt="" className="dark:invert" />
         </button>
       </header>
 
       {/* (only-PC) 새 블로그 작성 버튼 */}
-      <Link href="/post" className={`mx-3 mt-5 hidden items-center justify-center gap-3 rounded-sm bg-black text-base text-white hover:bg-hover pc:flex ${isSidebarOpen ? 'h-10' : 'h-9.5'}`}>
+      <Link href="/post" className={`mx-3 mt-5 hidden items-center justify-center gap-3 rounded-sm bg-black text-base text-white hover:bg-hover pc:flex ${isCollapsed ? 'h-9.5' : 'h-10'}`}>
         <PlusIcon className="h-3.5 w-3.5 text-white" />
-        <span className={isSidebarOpen ? '' : 'hidden'}>새 블로그 작성</span>
+        <span className={isCollapsed ? 'hidden' : ''}>새 블로그 작성</span>
       </Link>
 
-      {/* 블로그 목록 */}
-      <nav aria-label="블로그 목록" className={`flex-1 space-y-1 overflow-auto px-2.5 pt-5 pc:mx-3 pc:mt-8 pc:px-0 pc:pt-0`} aria-hidden={!isSidebarOpen}>
-        {!isSidebarOpen ? null : initialPosts.length === 0 ? (
+      {/* 블로그 목록 — 모바일/데스크탑 둘 다에서 보이므로 두 상태 모두 반영 */}
+      <nav aria-label="블로그 목록" className={`flex-1 space-y-1 overflow-auto px-2.5 pt-5 pc:mx-3 pc:mt-8 pc:px-0 pc:pt-0 ${isCollapsed ? 'pc:hidden' : ''} ${isSidebarOpen ? '' : 'max-pc:hidden'}`}>
+        {initialPosts.length === 0 ? (
           <div className="flex h-full justify-center text-primary">아직 작성한 블로그가 없습니다.</div>
         ) : (
           <ul>
-            {initialPosts.map((post, idx) => {
+            {initialPosts.map(post => {
               const isActive = pathname === `/post/${post.id}`;
               return (
                 <li key={post.id}>
@@ -72,12 +65,10 @@ export default function Sidebar({ initialPosts, userEmail }: { initialPosts: Pos
         )}
       </nav>
 
-      {/* 사이드바 푸터 */}
-      <footer className={`mt-auto flex border-t border-base-stroke px-4 py-4.5 ${isSidebarOpen ? 'justify-between' : 'justify-center max-pc:hidden'}`}>
-        {/* 계정 정보 */}
-        <span className={isSidebarOpen ? '' : 'hidden'}>{userEmail}</span>
+      {/* 사이드바 푸터 — 마찬가지로 두 상태 모두 반영 */}
+      <footer className={`mt-auto flex border-t border-base-stroke px-4 py-4.5 ${isCollapsed ? 'justify-center' : 'justify-between'} ${isSidebarOpen ? '' : 'max-pc:hidden'}`}>
+        <span className={isCollapsed ? 'hidden' : ''}>{userEmail}</span>
         <ThemeModeToggle />
-        {/* 로그아웃 버튼 */}
         <button
           type="button"
           aria-label="로그아웃"

--- a/stores/ui-store.ts
+++ b/stores/ui-store.ts
@@ -1,13 +1,21 @@
 import { create } from 'zustand';
 
 interface UIState {
-  isSidebarOpen: boolean;
+  isSidebarOpen: boolean; // 모바일 오버레이 열림 여부 (기본 false)
   toggleSidebar: () => void;
   setSidebarOpen: (open: boolean) => void;
+
+  isCollapsed: boolean; // 데스크탑 사이드바 접힘 여부 (기본 false = 펼침)
+  toggleCollapsed: () => void;
+  setCollapsed: (collapsed: boolean) => void;
 }
 
 export const useUIStore = create<UIState>(set => ({
   isSidebarOpen: false,
   toggleSidebar: () => set(state => ({ isSidebarOpen: !state.isSidebarOpen })),
   setSidebarOpen: open => set({ isSidebarOpen: open }),
+
+  isCollapsed: false,
+  toggleCollapsed: () => set(state => ({ isCollapsed: !state.isCollapsed })),
+  setCollapsed: collapsed => set({ isCollapsed: collapsed }),
 }));


### PR DESCRIPTION
## PR 유형

- [] 새로운 기능 추가
- [x] 버그 수정
- [] CSS 등 사용자 UI 디자인 변경
- [] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [] 주석 추가 및 수정
- [] 문서 수정
- [] 테스트 추가, 테스트 리팩토링
- [] 빌드 부분 혹은 패키지 매니저 수정
- [] 파일 혹은 폴더명 수정
- [] 파일 혹은 폴더 삭제

## PR 체크리스트

<!-- PR이 다음 요구 사항을 충족하는지 확인하세요. -->

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세

- ui-store.ts: 데스크탑 접힘 상태를 위한 isCollapsed/toggleCollapsed/ setCollapsed 추가 (모바일 오버레이용 isSidebarOpen과 역할 분리)
- Sidebar.tsx: 마운트 후 window.innerWidth를 체크해 사이드바를 열던 useEffect 제거. 데스크탑 펼침 상태를 isCollapsed 기본값(false) 으로 최초 렌더부터 확정해 폭이 사후에 바뀌는 현상 자체를 없앰 (only-PC 요소는 isCollapsed로, nav/footer는 isCollapsed+ isSidebarOpen을 함께 반영하도록 수정)
- layout.tsx: SidebarSkeleton 폭을 실제 Sidebar의 펼침 상태(w-75)와 동일하게 맞춰 Suspense fallback → 실제 컴포넌트 전환 시 레이아웃 변경이 발생하지 않도록 수정


## 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 예시 : resolves #1 -->

resolves <#1467694926484472124>
